### PR TITLE
Fixed args passed to scatter

### DIFF
--- a/huracan/engine.py
+++ b/huracan/engine.py
@@ -866,8 +866,8 @@ class stream(SET):
                 fig=fig,
                 # Further customization
                 plot_label=plot_label,
-                x_label=x_label,
-                y_label=y_label,
+                label_x=x_label,
+                label_y=y_label,
                 show=show,
                 **further_custom)
 


### PR DESCRIPTION
`mpl_plotter/two_d/plotters.py` scatter class has args for `label_x` and `label_y` rather than `x_label` and `y_label`, which broke this function